### PR TITLE
Update SPI driver

### DIFF
--- a/adxl345_code/include/spi.h
+++ b/adxl345_code/include/spi.h
@@ -1,13 +1,13 @@
 /**
  * @file spi.h
  * @author Jose Luis Figueroa 
- * @brief The interface definition for the spi. This is the header file for 
+ * @brief The interface definition for the SPI. This is the header file for 
  * the definition of the interface for a Serial Peripheral Serial (SPI) on 
  * a standard microcontroller.
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. All rights reserved.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. All rights reserved.
  * 
  */
 #ifndef SPI_H_
@@ -18,8 +18,36 @@
 *****************************************************************************/
 #include <stdint.h>
 #include <stdio.h>
+//#define NDEBUG          /*To disable assert function*/  
+#include <assert.h>
 #include "spi_cfg.h"
 #include "stm32f4xx.h"   
+
+/*****************************************************************************
+* Preprocessor Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Configuration Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Macros
+*****************************************************************************/
+
+/*****************************************************************************
+* Typedefs
+*****************************************************************************/
+typedef struct
+{
+    SpiChannel_t Channel;           /**< The SPI channel */
+    uint16_t size;                  /**< The size of the data */
+    uint16_t *data;                 /**< The data to be sent */
+}SpiTransferConfig_t;
+
+/*****************************************************************************
+* Variables
+*****************************************************************************/
 
 /*****************************************************************************
 * Function Prototypes
@@ -28,9 +56,9 @@
 extern "C"{
 #endif
 
-void SPI_init(const SpiConfig_t * const Config);
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size);
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size);
+void SPI_init(const SpiConfig_t * const Config, size_t configSize);
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig);
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig);
 void SPI_registerWrite(uint32_t address, uint32_t value);
 uint16_t SPI_registerRead(uint32_t address);
 

--- a/adxl345_code/include/spi_cfg.h
+++ b/adxl345_code/include/spi_cfg.h
@@ -2,35 +2,33 @@
  * @file spi_cfg.h
  * @author Jose Luis Figueroa 
  * @brief This module contains interface definitions for the SPI
- * configuration. This is the header file for the definition of the
- * interface for retrieving the Serial Peripheral interface
- * configuration table.
- * @version 1.0
- * @date 2023-07-14
+ * configuration. This is the header file for the definition of the interface
+ * for retrieving the Serial Peripheral interface configuration table.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 #ifndef SPI_CFG_H_
 #define SPI_CFG_H_
 
-/**********************************************************************
+/*****************************************************************************
+* Includes
+*****************************************************************************/
+#include <stdio.h>
+
+/****************************************************************************
 * Preprocessor Constants
-**********************************************************************/
+*****************************************************************************/
 /** 
  * Defines the number of ports on the processor.
  */
 #define SPI_PORTS_NUMBER 4U
 
-/** 
- * Set the value according with the number of Serial Peripheral 
- * interface channels to be used.
-*/
-#define SPI_CHANNELS_NUMBER 1
-
-/**********************************************************************
+/****************************************************************************
 * Typedefs
-**********************************************************************/
+*****************************************************************************/
 /**
  * Define the SPI channels on the MCU device. It is used to specify
  * SPI channel to configure the register map.
@@ -95,7 +93,7 @@ typedef enum
     SPI_SOFTWARE_NSS,           /**< Software NSS pin management*/
     SPI_HARDWARE_NSS_ENABLED,   /**< Hardware NSS pin management (Master)*/
     SPI_HARDWARE_NSS_DISABLED,  /**< Hardware NSS pin management (slave)*/
-    SPI_MAX_NSS             /**< Maximum NSS input*/
+    SPI_MAX_NSS                 /**< Maximum NSS input*/
 }SpiSlaveSelect_t;
 
 /**
@@ -154,6 +152,7 @@ extern "C"{
 #endif
 
 const SpiConfig_t * const SPI_ConfigGet(void);
+size_t SPI_configSizeGet(void);
 
 #ifdef __cplusplus
 } //extern "C"

--- a/adxl345_code/src/spi.c
+++ b/adxl345_code/src/spi.c
@@ -1,17 +1,29 @@
 /**
  * @file spi.c
  * @author Jose Luis Figueroa 
- * @brief The implementation for the SPI.
- * @version 1.0
- * @date 2023-07-14
+ * @brief The implementation for the SPI Driver.
+ * @version 1.1
+ * @date 2025-03-11
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 /*****************************************************************************
 * Includes
 *****************************************************************************/
 #include "spi.h"
+
+/*****************************************************************************
+* Module Preprocessor Constants
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Preprocessor Macros
+*****************************************************************************/
+
+/*****************************************************************************
+* Module Typedefs
+*****************************************************************************/
 
 /*****************************************************************************
 * Module Variable Definitions
@@ -55,39 +67,50 @@ static uint16_t volatile * const dataRegister[SPI_PORTS_NUMBER] =
  * Function: SPI_init()
 *//**
 *\b Description:
- * This function is used to initialize the spi based on the configuration  
+ * This function is used to initialize the SPI based on the configuration  
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
- * PRE-CONDITION: SPI pins should be configured using GPIO driver.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI pins should be configured using GPIO driver. <br>
  * PRE-CONDITION: Configuration table needs to be populated (sizeof > 0) <br>
+ * PRE-CONDITION: The setting is within the maximum values (SPI_MAX). <br>
  *
- * POST-CONDITION: The peripheral is set up with the configuration settings.
+ * POST-CONDITION: The peripheral is set up with the configuration settings. <br>
  * 
  * @param[in]   Config is a pointer to the configuration table that contains 
- *               the initialization for the peripheral.
+ *               the initialization for the peripheral. 
+ * @param[in]   configSize is the size of the configuration table. 
  * 
- * @return  void
- * 
+ * @return  void 
+ *  
  * \b Example:
  * @code
  *  const SpiConfig_t * const SpiConfig = SPI_configGet();
- *  SPI_init(DioConfig);
+ *  size_t configSize = SPI_configSizeGet();
+ * 
+ *  SPI_Init(DioConfig, configSize);
  * @endcode
  * 
  * @see SPI_configGet
- * @see SPI_init
- * @see SPI_transfer
- * @see SPI_registerWrite
- * @see SPI_registerRead
- * @see SPI_callbackRegister
+ * @see SPI_getConfigSize
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
  * 
 *****************************************************************************/
-void SPI_init(const SpiConfig_t * const Config)
+void SPI_init(const SpiConfig_t * const Config, size_t configSize)
 {
     /**Loop through all the elements of the configuration table.*/
-    for(uint8_t i=0; i<SPI_CHANNELS_NUMBER; i++)
+    for(uint8_t i=0; i<configSize; i++)
     {
+        /* Prevent to assign a value out of the range of the channels.
+         * The registers arrays are limited to the SPI_PORTS_NUMBER, higher 
+         * value can cause a memory violation.
+        */
+       assert(Config[i].Channel < SPI_MAX_CHANNEL);
+
         /**Set the configuration of the SPI on the control register 1*/
         /**Set the Clock phase and polarity modes*/
         if(Config[i].Mode == SPI_MODE0)
@@ -112,7 +135,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This mode does not exist\n");
+            assert(Config[i].Mode < SPI_MAX_MODE);
         }
 
         /**Set the hierarchy of the device*/
@@ -126,7 +149,7 @@ void SPI_init(const SpiConfig_t * const Config)
         } 
         else
         {
-            printf("This hierarchy does not exist\n");
+            assert(Config[i].Hierarchy < SPI_MAX_HIERARCHY);
         }
 
         /**Set the baud rate of the device*/
@@ -180,7 +203,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This baud rate does not exist\n");
+            assert(Config[i].BaudRate < SPI_MAX_FPCLK);
         }
 
         /**Set the slave select pin management for the device*/
@@ -201,7 +224,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This slave select pin option does not exist\n");
+            assert(Config[i].SlaveSelect < SPI_MAX_NSS);
         }
 
         /**Set the frame format of the device*/
@@ -215,7 +238,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This frame format does not exist\n");
+            assert(Config[i].FrameFormat < SPI_MAX_FF);
         }
 
         /**Set the data transfer type of the device*/
@@ -229,7 +252,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data transfer type does not exist");
+            assert(Config[i].TypeTransfer < SPI_MAX_DF);
         }
 
         /**Set the data frame format (size) of the device*/
@@ -243,7 +266,7 @@ void SPI_init(const SpiConfig_t * const Config)
         }
         else
         {
-            printf("This data size does not exist\n");
+            assert(Config[i].DataSize < SPI_MAX_BITS);
         }
 
         /**Enable the SPI module*/
@@ -252,116 +275,153 @@ void SPI_init(const SpiConfig_t * const Config)
 
 }
 
-/**********************************************************************
- * Function: SPI_transfer()
+/*****************************************************************************
+ * Function: SPI_Transfer()
 *//**
  *\b Description:
- * This function is used to initialize a data transfer on the SPI bus. 
+ * This function is used to initialize a data transfer on the SPI bus. This 
+ * function is used to send data to a slave device specified by the 
+ * SpiTransferConfig_t structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
- * POST-CONDITION: Data transferred based on configuration.
+ * POST-CONDITION: Data transferred based on configuration. <br>
  * 
- * @param[in]   Channel is the SPI from SpiChannel_t used to transfer data.
- * @param[in]   data is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_transfer(*data, size);
+ * uint16_t data[] = {0x56};
+ * SpiTransferConfig_t TransferConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(data)/sizeof(data[0]),
+ *     .data = data
+ * };
+ * SPI_Transfer(&TransferConfig);
  * @endcode
  * 
  * @see SPI_configGet
- * @see SPI_init
- * @see SPI_transfer
- * @see SPI_registerWrite
- * @see SPI_registerRead
- * @see SPI_callbackRegister
+ * @see SPI_getConfigSize
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_transfer(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_transfer(const SpiTransferConfig_t * const TransferConfig)
 {
-    for(uint16_t i=0; i<size; i++)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig->data != NULL);
+
+    for (uint16_t i = 0; i < TransferConfig->size; i++)
     {
         /* Wait until TXE is set (buffer empty)*/
-        while(!(*statusRegister[Channel] & SPI_SR_TXE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
         {
             asm("nop");
         }
-        *dataRegister[Channel] = data[i];
+        *dataRegister[TransferConfig->Channel] = TransferConfig->data[i];
     }
 
     /* Wait until TXE is set to ensure the bus is empty*/
-    while(!(*statusRegister[Channel] & SPI_SR_TXE))
+    while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_TXE))
     {
         asm("nop");
     }
 
     /* Wait until bus is not busy to reset*/
-    while(*statusRegister[Channel] & SPI_SR_BSY)
+    while(*statusRegister[TransferConfig->Channel] & SPI_SR_BSY)
     {
         asm("nop");
     }
 
     /* Clear OVR bit (Overrun flag) in case of error*/
     uint16_t clearingFlag;
-    clearingFlag = *dataRegister[Channel];
-    clearingFlag = *statusRegister[Channel];
+    clearingFlag = *dataRegister[TransferConfig->Channel];
+    clearingFlag = *statusRegister[TransferConfig->Channel];
 }
 
-/**********************************************************************
- * Function: SPI_receive()
+/*****************************************************************************
+ * Function: SPI_Receive()
 *//**
  *\b Description:
- * This function is used to initialize a data reception on the SPI bus. 
+ * This function is used to initialize a data reception on the SPI bus. This 
+ * function is used to receive data specified by the  SpiTransferConfig_t 
+ * structure, which contains the channel, size, and data.
  * 
- * PRE-CONDITION: SPI_Init must be called with valid configuration data.
- * PRE-CONDITION: SpiTransfer_t needs to be populated.
- * PRE-CONDITION: The MCU clocks must be configured and enabled.
+ * PRE-CONDITION: The MCU clocks must be configured and enabled. <br>
+ * PRE-CONDITION: SPI_Init must be called with valid configuration data. <br>
+ * PRE-CONDITION: SpiTransferConfig_t needs to be populated. <br>
+ * PRE-CONDITION: The Channel is within the maximum SpiChannel_t. <br>
+ * PRE-CONDITION: The size is greater than 0. <br>
+ * PRE-CONDITION: The data is not NULL. <br>
  * 
  * POST-CONDITION: Data transferred based on configuration.
  * 
- * @param[in]   Channel is the SPI from SpiChannel_t used to transfer data.
- * @param[in]   data is the information to be sent.
- * @param[in]   size is data size.
+ * @param[in] SpiTransferConfig A pointer to a structure containing the 
+ * channel, size, and data to be read.
  * 
  * @return  void
  * 
  * \b Example:
  * @code
- *  SPI_receive(*data, size);
+* uint16_t rxdata[1];
+ * SpiTransferConfig_t ReceiveConfig =
+ * {
+ *     .Channel = SPI_CHANNEL1,
+ *     .size = sizeof(rxdata)/sizeof(rxdata[0]),
+ *     .data = rxdata
+ * };
+ * SPI_receive(&ReceiveConfig);
  * @endcode
  * 
  * @see SPI_configGet
- * @see SPI_init
- * @see SPI_transfer
- * @see SPI_registerWrite
- * @see SPI_registerRead
- * @see SPI_callbackRegister
+ * @see SPI_getConfigSize
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
  * 
- **********************************************************************/
-void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
+ ****************************************************************************/
+void SPI_receive(const SpiTransferConfig_t * const TransferConfig)
 {
-    while(size)
+    /* Prevent to assign a value out of the range of the channel*/
+    assert(TransferConfig->Channel < SPI_MAX_CHANNEL);
+    /* Prevent to use an empty data size*/
+    assert(TransferConfig->size > 0);
+    /* Prevent to use an empty data transfer*/
+    assert(TransferConfig != NULL);
+
+    for (uint8_t i = 0; i < TransferConfig->size; i++)
     {
         /* Send dummy data (Recommended).*/
-        *dataRegister[Channel] = 0;
+        *dataRegister[TransferConfig->Channel] = 0;
         /* Wait for RXEN flag to be sent*/
-        while(!(*statusRegister[Channel] & SPI_SR_RXNE))
+        while(!(*statusRegister[TransferConfig->Channel] & SPI_SR_RXNE))
         {
             asm("nop");
         }
         /* Read the data*/
-        *data++ = *dataRegister[Channel];
-        size--;
+        TransferConfig->data[i] = *dataRegister[TransferConfig->Channel];
     }
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerWrite()
 *//**
  *\b Description:
@@ -371,10 +431,10 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register
- * address space.
+ * address space. <br>
  * 
- * POST-CONDITION: The register located at address is updated with
- * value.
+ * POST-CONDITION: The register located at address with be updated with
+ * value. <br>
  * 
  * @param[in]   address is a register address within the SPI peripheral
  *              map.
@@ -388,20 +448,21 @@ void SPI_receive(SpiChannel_t Channel, uint16_t *data, uint16_t size)
  * @endcode
  * 
  * @see SPI_configGet
- * @see SPI_init
- * @see SPI_transfer
- * @see SPI_registerWrite
- * @see SPI_registerRead
- * @see SPI_callbackRegister
+ * @see SPI_configSizeGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
  * 
-**********************************************************************/  
+****************************************************************************/  
 void SPI_registerWrite(uint32_t address, uint32_t value)
 {
     volatile uint32_t * const registerPointer = (uint32_t*)address;
     *registerPointer = value;
 }
 
-/**********************************************************************
+/*****************************************************************************
  * Function: SPI_registerRead()
 *//**
  *\b Description:
@@ -411,10 +472,10 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * interface.
  * 
  * PRE-CONDITION: Address is within the boundaries of the SPI register 
- * address space.
+ * address space. <br>
  * 
  * POST-CONDITION: The value stored in the register is returned to the 
- * caller.
+ * caller. <br>
  * 
  * @param[in]   address is the address of the SPI register to read.
  * 
@@ -426,13 +487,14 @@ void SPI_registerWrite(uint32_t address, uint32_t value)
  * @endcode
  * 
  * @see SPI_configGet
- * @see SPI_init
- * @see SPI_transfer
- * @see SPI_registerWrite
- * @see SPI_registerRead
- * @see SPI_callbackRegister
+ * @see SPI_configSizeGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
  *
- **********************************************************************/
+ ****************************************************************************/
 uint16_t SPI_registerRead(uint32_t address)
 {
     volatile uint16_t * const registerPointer = (uint16_t *)address;

--- a/adxl345_code/src/spi_cfg.c
+++ b/adxl345_code/src/spi_cfg.c
@@ -3,10 +3,10 @@
  * @author Jose Luis Figueroa.
  * @brief This module contains the implementation for the Serial Peripheral
  * Interface (SPI).
- * @version 1.0
- * @date 2023-07-14
+ * @version 1.1
+ * @date 2025-03-19
  * 
- * @copyright Copyright (c) 2023 Jose Luis Figueroa. MIT License.
+ * @copyright Copyright (c) 2025 Jose Luis Figueroa. MIT License.
  * 
  */
 
@@ -23,8 +23,7 @@
  * Peripheral Interface. Each row represent a single SPI configuration.
  * Each column is representing a member of the SpiConfig_t structure. This 
  * table is read in by SPI_Init, where each channel is then set up based on 
- * this table. The SPI_CHANNELS_NUMBER constant should be agreed with the 
- * number of row.
+ * this table. 
 */
 const SpiConfig_t SpiConfig[] = 
 {
@@ -51,19 +50,22 @@ const SpiConfig_t SpiConfig[] =
  * This function is used to initialize the SPI based on the configuration
  * table defined in spi_cfg module.
  * 
- * PRE-CONDITION: configuration table needs to be populated (sizeof > 0)
- * POST-CONDITION: A constant pointer to the first member of the  
- * configuration table will be returned.
- * @return A pointer to the configuration table.
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0). <br>
+ * POST-CONDITION: A constant pointer to the first member of the configuration 
+ * table will be returned. <br>
+ * 
+ * @return A pointer to the configuration table. <br>
  * 
  * \b Example: 
  * @code
  * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
  * 
- * SPI_Init(SpiConfig);
+ * SPI_Init(SpiConfig, configSize);
  * @endcode
- * 
- * @see SPI_ConfigGet
+ *
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
  * @see SPI_Init
  * @see SPI_Transfer
  * @see SPI_RegisterWrite
@@ -79,4 +81,39 @@ const SpiConfig_t * const SPI_ConfigGet(void)
    */
   return (const SpiConfig_t*)&SpiConfig[0];
 
+}
+
+/*****************************************************************************
+ * Function: SPI_configSizeGet()
+*/
+/**
+*\b Description:
+ * This function is used to get the size of the configuration table.
+ * 
+ * PRE-CONDITION: configuration table needs to be populated (sizeof > 0) <br>
+ * 
+ * POST-CONDITION: The size of the configuration table will be returned. <br>
+ * 
+ * @return The size of the configuration table. <br>
+ * 
+ * \b Example: 
+ * @code
+ * const SpiConfig_t * const SpiConfig = SPI_ConfigGet();
+ * size_t configSize = DIO_configSizeGet();
+ * 
+ * SPI_Init(SpiConfig, configSize);
+ * @endcode
+ * 
+ * @see SPI_configGet
+ * @see SPI_configSizeGet
+ * @see SPI_Init
+ * @see SPI_Transfer
+ * @see SPI_RegisterWrite
+ * @see SPI_RegisterRead
+ * @see SPI_CallbackRegister
+ * 
+*****************************************************************************/
+size_t SPI_configSizeGet(void)
+{
+   return sizeof(SpiConfig)/sizeof(SpiConfig[0]);
 }


### PR DESCRIPTION
The following updates were added:
- The SPI_configSizeGet function was added to get the table size automatically.
- The assert macro implementation (design by contract) is added to catch bux on the development stage.
- Modified function arguments to pass structures by pointer (SpiTransferConfig_t) instead of by value. This reduces 
  memory overhead and allows direct modification of struct members without unnecessary copies and a defensive 
  programming approach.
- The comments were updated according to the updates.